### PR TITLE
Added methods that accept logger for the transformation process or use default one.

### DIFF
--- a/src/Cake.XdtTransform.Tests/Cake.XdtTransform.Tests.csproj
+++ b/src/Cake.XdtTransform.Tests/Cake.XdtTransform.Tests.csproj
@@ -43,6 +43,9 @@
       <HintPath>..\packages\Fixie.1.0.2\lib\net45\Fixie.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
     <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
       <Private>True</Private>
@@ -81,11 +84,16 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Util\CultureUtil.cs" />
+    <Compile Include="XdtTransformationLogTests.cs" />
+    <Compile Include="XdtTransformationLogEntryTests.cs" />
     <Compile Include="XdtTransformationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.XdtTransform\Cake.XdtTransform.csproj">

--- a/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
+++ b/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
@@ -49,5 +49,9 @@ namespace Cake.XdtTransform.Tests.Fixtures
         public void TransformConfig() {
             XdtTransformation.TransformConfig(FileSystem, SourceFile, TransformFile, TargetFile);
         }
+
+        public XdtTransformationLog TransformConfigWithDefaultLogger() {
+            return XdtTransformation.TransformConfigWithDefaultLogger(FileSystem, SourceFile, TransformFile, TargetFile);
+        }
     }
 }

--- a/src/Cake.XdtTransform.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.XdtTransform.Tests/Properties/Resources.Designer.cs
@@ -65,6 +65,7 @@ namespace Cake.XdtTransform.Tests.Properties {
         ///&lt;configuration xmlns:xdt=&quot;http://schemas.microsoft.com/XML-Document-Transform&quot;&gt;
         ///    &lt;appSettings&gt;
         ///        &lt;add key=&quot;transformed&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
+        ///	&lt;add key=&quot;this-is-missing&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
         ///    &lt;/appSettings&gt;
         ///  &lt;system.web&gt;
         ///    &lt;compilation xdt:Transform=&quot;RemoveAttributes(debug)&quot; /&gt;

--- a/src/Cake.XdtTransform.Tests/Properties/Resources.resx
+++ b/src/Cake.XdtTransform.Tests/Properties/Resources.resx
@@ -122,6 +122,7 @@
 &lt;configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"&gt;
     &lt;appSettings&gt;
         &lt;add key="transformed" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
+	&lt;add key="this-is-missing" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
     &lt;/appSettings&gt;
   &lt;system.web&gt;
     &lt;compilation xdt:Transform="RemoveAttributes(debug)" /&gt;

--- a/src/Cake.XdtTransform.Tests/Util/CultureUtil.cs
+++ b/src/Cake.XdtTransform.Tests/Util/CultureUtil.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cake.XdtTransform.Tests.Util
+{
+    public static class CultureUtil
+    {
+        public static void UseGBCulture(Action test)
+        {
+            var currentThread = Thread.CurrentThread;
+            var existingCulture = currentThread.CurrentCulture;
+            var existingUiCulture = currentThread.CurrentUICulture;
+
+            var GbCulture = CultureInfo.CreateSpecificCulture("en-GB");
+            currentThread.CurrentCulture = GbCulture;
+            currentThread.CurrentUICulture = GbCulture;
+
+            try
+            {
+                test();
+            }
+            finally
+            {
+                currentThread.CurrentCulture = existingCulture;
+                currentThread.CurrentUICulture = existingUiCulture;
+            }
+        }
+    }
+}

--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
@@ -49,8 +49,9 @@ namespace Cake.XdtTransform.Tests
                 stringRepresentation = item.ToString();              
             });
 
-            stringRepresentation.ShouldStartWith(@"[02/01/2000 03:04:05] [MessageType:Type] [MessageVerbosityType:Verbose] [File:File] [LineNumber:10] [LinePosition:20] Exception: System.Exception: Exception was thrown.
-   at Cake.XdtTransform.Tests.XdtTransformationLogEntryTests.ForFullItemToStringIsMaximum() in ");
+            stringRepresentation.ShouldStartWith(@"[02/01/2000 03:04:05] [MessageType:Type] [MessageVerbosityType:Verbose] [File:File] [LineNumber:10] [LinePosition:20] Exception: System.Exception: Exception was thrown.");
+
+            stringRepresentation.ShouldContain("at Cake.XdtTransform.Tests.XdtTransformationLogEntryTests.ForFullItemToStringIsMaximum() in ");
 
             stringRepresentation.ShouldContain("Message arg0 30");
         }

--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
@@ -50,7 +50,7 @@ namespace Cake.XdtTransform.Tests
             });
 
             stringRepresentation.ShouldStartWith(@"[02/01/2000 03:04:05] [MessageType:Type] [MessageVerbosityType:Verbose] [File:File] [LineNumber:10] [LinePosition:20] Exception: System.Exception: Exception was thrown.
-   at Cake.XdtTransform.Tests.XdtTransformationLogEntryTests.ForFullItemToStringIsMaximum() in C:\Github\Cake.XdtTransform\src\Cake.XdtTransform.Tests\XdtTransformationLogEntryTests.cs:line");
+   at Cake.XdtTransform.Tests.XdtTransformationLogEntryTests.ForFullItemToStringIsMaximum() in ");
 
             stringRepresentation.ShouldContain("Message arg0 30");
         }

--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.Web.XmlTransform;
+using Cake.XdtTransform.Tests.Util;
+using Should;
+
+namespace Cake.XdtTransform.Tests
+{
+    public sealed class XdtTransformationLogEntryTests
+    {
+        public void ForEmptyItemToStringIsMinimum()
+        {
+            var stringRepresentation = "";
+             var item = new XdtTransformationLogEntry();
+            item.Timestamp = new DateTime(2000, 1, 2, 3, 4, 5);
+
+            CultureUtil.UseGBCulture(() =>
+            {              
+                stringRepresentation = item.ToString();             
+            });
+
+            stringRepresentation.ShouldEqual("[02/01/2000 03:04:05] ");
+        }
+
+        public void ForFullItemToStringIsMaximum()
+        {
+            var item = new XdtTransformationLogEntry();
+            item.File = "File";
+            item.LineNumber = 10;
+            item.LinePosition = 20;
+            item.Message = "Message {0} {1}";
+            item.MessageArgs = new object[] { "arg0", 30 };
+            item.MessageVerbosityType = MessageType.Verbose;
+            item.MessageType = "Type";
+            item.Timestamp = new DateTime(2000, 1, 2, 3, 4, 5);
+
+            try
+            {
+                throw new Exception("Exception was thrown.");
+            }
+            catch (Exception ex)
+            {
+                item.Exception = ex;
+            }
+
+            var stringRepresentation = "";
+
+            CultureUtil.UseGBCulture(() =>
+            {
+                stringRepresentation = item.ToString();              
+            });
+
+            stringRepresentation.ShouldStartWith(@"[02/01/2000 03:04:05] [MessageType:Type] [MessageVerbosityType:Verbose] [File:File] [LineNumber:10] [LinePosition:20] Exception: System.Exception: Exception was thrown.
+   at Cake.XdtTransform.Tests.XdtTransformationLogEntryTests.ForFullItemToStringIsMaximum() in C:\Github\Cake.XdtTransform\src\Cake.XdtTransform.Tests\XdtTransformationLogEntryTests.cs:line");
+
+            stringRepresentation.ShouldContain("Message arg0 30");
+        }
+    }
+}

--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Web.XmlTransform;
+using Cake.XdtTransform.Tests.Util;
+using Should;
+
+namespace Cake.XdtTransform.Tests
+{
+    public sealed class XdtTransformationLogTests
+    {
+        public void ImplementsEveryInterfaceMethodAndSavesAllLogEntries()
+        {
+            CultureUtil.UseGBCulture(() =>
+            {
+                var log = new XdtTransformationLog();
+
+                log.HasError.ShouldBeFalse();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeFalse();
+                log.Log.Count().ShouldEqual(0);
+
+                log.LogMessage("Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeFalse();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeFalse();
+                log.Log.Count().ShouldEqual(1);
+                log.Log.ElementAt(0).ToString().ShouldContain("[MessageType:Message] Message 1 2");
+
+                log.LogMessage(MessageType.Verbose, "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeFalse();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeFalse();
+                log.Log.Count().ShouldEqual(2);
+                log.Log.ElementAt(1).ToString().ShouldContain("[MessageType:Message] [MessageVerbosityType:Verbose] Message 1 2");
+
+                log.LogWarning("File", "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeFalse();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(3);
+                log.Log.ElementAt(2).ToString().ShouldContain("[MessageType:Warning] [File:File] Message 1 2");
+
+                log.LogWarning("File", 30, 40, "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeFalse();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(4);
+                log.Log.ElementAt(3).ToString().ShouldContain("[MessageType:Warning] [File:File] [LineNumber:30] [LinePosition:40] Message 1 2");
+
+                log.LogError("Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(5);
+                log.Log.ElementAt(4).ToString().ShouldContain("[MessageType:Error] Message 1 2");
+
+                log.LogError("File","Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(6);
+                log.Log.ElementAt(5).ToString().ShouldContain("[MessageType:Error] [File:File] Message 1 2");
+
+                log.LogError("File", 30, 40, "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeFalse();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(7);
+                log.Log.ElementAt(6).ToString().ShouldContain("[MessageType:Error] [File:File] [LineNumber:30] [LinePosition:40] Message 1 2");
+
+                Exception exception = null;
+                try
+                {
+                    throw new Exception("Exception was thrown");
+                }
+                catch(Exception ex)
+                {
+                    exception = ex;
+                }
+
+                log.LogErrorFromException(exception);
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(8);
+                log.Log.ElementAt(7).ToString().ShouldContain("[MessageType:Exception] Exception: System.Exception: Exception was thrown");
+
+                log.LogErrorFromException(exception, "File");
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(9);
+                log.Log.ElementAt(8).ToString().ShouldContain("[MessageType:Exception] [File:File] Exception: System.Exception: Exception was thrown");
+
+                log.LogErrorFromException(exception, "File", 30, 40);
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(10);
+                log.Log.ElementAt(9).ToString().ShouldContain("[MessageType:Exception] [File:File] [LineNumber:30] [LinePosition:40] Exception: System.Exception: Exception was thrown");
+
+                log.StartSection("Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(11);
+                log.Log.ElementAt(10).ToString().ShouldContain("[MessageType:Section] Message 1 2");
+
+                log.StartSection(MessageType.Verbose, "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(12);
+                log.Log.ElementAt(11).ToString().ShouldContain("[MessageType:Section] [MessageVerbosityType:Verbose] Message 1 2");
+
+                log.EndSection("Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(13);
+                log.Log.ElementAt(12).ToString().ShouldContain("[MessageType:Section] Message 1 2");
+
+                log.EndSection(MessageType.Verbose, "Message {0} {1}", new object[] { "1", 2 });
+                log.HasError.ShouldBeTrue();
+                log.HasException.ShouldBeTrue();
+                log.HasWarning.ShouldBeTrue();
+                log.Log.Count().ShouldEqual(14);
+                log.Log.ElementAt(13).ToString().ShouldContain("[MessageType:Section] [MessageVerbosityType:Verbose] Message 1 2");
+            });
+        }
+    }
+}

--- a/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
@@ -87,5 +87,36 @@ namespace Cake.XdtTransform.Tests {
             }
             transformedString.ShouldContain("<add key=\"transformed\" value=\"false\"/>");
         }
+
+        public void ShouldTransformFileWithDefaultLogger()
+        {
+            // Given
+            var fixture = new XdtTransformationFixture
+            {
+                TargetFile = "/Working/transformed.config"
+            };
+
+            // When
+            var  log = fixture.TransformConfigWithDefaultLogger();
+
+            // Then
+            var transformedFile = fixture.FileSystem.GetFile(fixture.TargetFile);
+            transformedFile.Exists.ShouldEqual(true);
+            string transformedString;
+            using (var transformedStream = transformedFile.OpenRead())
+            {
+                using (var streamReader = new StreamReader(transformedStream, Encoding.UTF8))
+                {
+                    transformedString = streamReader.ReadToEnd();
+                }
+            }
+            transformedString.ShouldContain("<add key=\"transformed\" value=\"false\"/>");
+            transformedString.ShouldNotContain("this-is-missing");
+
+            log.HasError.ShouldBeFalse();
+            log.HasException.ShouldBeFalse();
+            log.HasWarning.ShouldBeTrue();
+            log.Log.Count.ShouldEqual(15);
+        }
     }
 }

--- a/src/Cake.XdtTransform.Tests/packages.config
+++ b/src/Cake.XdtTransform.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Cake.Testing" version="0.16.2" targetFramework="net45" />
   <package id="Fixie" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />

--- a/src/Cake.XdtTransform/Cake.XdtTransform.csproj
+++ b/src/Cake.XdtTransform/Cake.XdtTransform.csproj
@@ -53,6 +53,8 @@
     <Compile Include="XdtTransformation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XdtTransformationAlias.cs" />
+    <Compile Include="XdtTransformationLog.cs" />
+    <Compile Include="XdtTransformationLogEntry.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Cake.XdtTransform/XdtTransformation.cs
+++ b/src/Cake.XdtTransform/XdtTransformation.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
+using Microsoft.Web.XmlTransform;
 using Cake.Core;
 using Cake.Core.IO;
-using Microsoft.Web.XmlTransform;
 
 namespace Cake.XdtTransform {
     /// <summary>
@@ -31,15 +31,31 @@ namespace Cake.XdtTransform {
             }
         }
 
-
         /// <summary>
-        /// Transforms config file.
+        /// Transforms config file and returns transformation log.
         /// </summary>
         /// <param name="fileSystem">The filesystem.</param>
         /// <param name="sourceFile">Source config file.</param>
         /// <param name="transformFile">Tranformation to apply.</param>
         /// <param name="targetFile">Target config file.</param>
-        public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
+        public static XdtTransformationLog TransformConfigWithDefaultLogger(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile)
+        {
+            var log = new XdtTransformationLog();
+
+            TransformConfig(fileSystem, sourceFile, transformFile, targetFile, log);
+
+            return log;
+        }
+
+            /// <summary>
+            /// Transforms config file.
+            /// </summary>
+            /// <param name="fileSystem">The filesystem.</param>
+            /// <param name="sourceFile">Source config file.</param>
+            /// <param name="transformFile">Tranformation to apply.</param>
+            /// <param name="targetFile">Target config file.</param>
+            /// <param name="logger">Logger for the transfomration process</param>
+            public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile, IXmlTransformationLogger logger = null) {
             if (fileSystem == null) {
                 throw new ArgumentNullException(nameof(fileSystem), "File system is null.");
             }
@@ -55,7 +71,7 @@ namespace Cake.XdtTransform {
                 transformStream = transformConfigFile.OpenRead(),
                 targetStream = targetConfigFile.OpenWrite())
             using (var document = new XmlTransformableDocument { PreserveWhitespace = true })
-            using (var transform = new XmlTransformation(transformStream, null))
+            using (var transform = new XmlTransformation(transformStream, logger))
             {
                 document.Load(sourceStream);
 

--- a/src/Cake.XdtTransform/XdtTransformationAlias.cs
+++ b/src/Cake.XdtTransform/XdtTransformationAlias.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Web.XmlTransform;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -38,6 +39,90 @@ namespace Cake.XdtTransform {
                 throw new ArgumentNullException(nameof(context));
             }
             XdtTransformation.TransformConfig(sourceFile, transformFile, targetFile);
+        }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library, allows you to pass a custom logger
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        /// 
+        ///     Microsoft.Web.XmlTransform.IXmlTransformationLogger logger = GetLogger();
+        /// 
+        ///     var sourceFile = File("web.config");
+        ///     var transformFile = File("web.release.config");
+        ///     var targetFile = File("web.target.config");
+        ///     XdtTransformConfigWithLogger(sourceFile, transformFile, targetFile, logger);
+        ///     
+        ///     AnalyzeLog(logger);
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.</param>
+        /// <param name="transformFile">Transformation file.</param>
+        /// <param name="targetFile">Output file name for the transformed file.</param>
+        /// <param name="logger">Logger for the transformation process</param>
+        [CakeMethodAlias]
+        public static void XdtTransformConfigWithLogger(this ICakeContext context, FilePath sourceFile, FilePath transformFile,
+    FilePath targetFile, IXmlTransformationLogger logger)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            XdtTransformation.TransformConfig(context.FileSystem, sourceFile, transformFile, targetFile, logger);
+        }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library and returns transformation log
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        /// 
+        ///     var sourceFile = File("web.config");
+        ///     var transformFile = File("web.release.config");
+        ///     var targetFile = File("web.target.config");
+        ///     var log = XdtTransformConfigWithDefaultLogger(sourceFile, transformFile, targetFile, logger);
+        ///     
+        ///     if(log.HasWarning)
+        ///     {
+        ///         var warnings = log.Log
+        ///                           .Where(entry => entry.MessageType == XdtTransformationLog.Warning)
+        ///                           .Select(entry => entry.ToString());
+        ///                           
+        ///         var concatWarnings = string.Join("\r\n", warnings);
+        ///         
+        ///         throw new Exception("Transformation has warnings:\r\n" + concatWarnings);
+        ///     }
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.</param>
+        /// <param name="transformFile">Transformation file.</param>
+        /// <param name="targetFile">Output file name for the transformed file.</param>
+        [CakeMethodAlias]
+        public static XdtTransformationLog XdtTransformConfigWithDefaultLogger(this ICakeContext context, FilePath sourceFile, FilePath transformFile,
+    FilePath targetFile)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            return XdtTransformation.TransformConfigWithDefaultLogger(context.FileSystem, sourceFile, transformFile, targetFile);
         }
     }
 }

--- a/src/Cake.XdtTransform/XdtTransformationLog.cs
+++ b/src/Cake.XdtTransform/XdtTransformationLog.cs
@@ -1,0 +1,250 @@
+﻿using Microsoft.Web.XmlTransform;
+using System;
+using System.Collections.Generic;
+
+namespace Cake.XdtTransform
+{
+    /// <summary>
+    /// Implementation of IXmlTransformationLogger that simply saves all entries.
+    /// </summary>
+    public class XdtTransformationLog : IXmlTransformationLogger
+    {
+        /// <summary>
+        /// String marker for entries containing errors.
+        /// </summary>
+        public const string Error = "Error";
+        /// <summary>
+        /// String marker for entries containing exceptions.
+        /// </summary>
+        public const string Exception = "Exception";
+        /// <summary>
+        /// String marker for entries containing warnings.
+        /// </summary>
+        public const string Warning = "Warning";
+        /// <summary>
+        /// String marker for entries containing messages.
+        /// </summary>
+        public const string Message = "Message";
+        /// <summary>
+        /// String marker for entries entries containing section start'end information.
+        /// </summary>
+        public const string Section = "Section";
+        /// <summary>
+        /// Log entries.
+        /// </summary>
+        public List<XdtTransformationLogEntry> Log { get; set; } = new List<XdtTransformationLogEntry>();
+        /// <summary>
+        /// True if at least one entry was for an error.
+        /// </summary>
+        public bool HasError { get; set; } = false;
+        /// <summary>
+        /// True if at least one entry was for an exception.
+        /// </summary>
+        public bool HasException { get; set; } = false;
+        /// <summary>
+        /// True if at least one entry was for a warning.
+        /// </summary>
+        public bool HasWarning { get; set; } = false;
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void EndSection(string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Section,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void EndSection(MessageType type, string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Section,
+                MessageVerbosityType = type,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogError(string message, params object[] messageArgs)
+        {
+            HasError = true;           
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Error,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogError(string file, string message, params object[] messageArgs)
+        {
+            HasError = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Error,
+                File = file,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogError(string file, int lineNumber, int linePosition, string message, params object[] messageArgs)
+        {
+            HasError = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Error,
+                File = file,
+                LineNumber = lineNumber,
+                LinePosition = linePosition,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogErrorFromException(Exception ex)
+        {
+            HasException = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Exception,
+                Exception = ex
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogErrorFromException(Exception ex, string file)
+        {
+            HasException = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Exception,
+                Exception = ex,
+                File = file
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogErrorFromException(Exception ex, string file, int lineNumber, int linePosition)
+        {
+            HasException = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Exception,
+                Exception = ex,
+                File = file,
+                LineNumber = lineNumber,
+                LinePosition = linePosition
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogMessage(string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Message,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogMessage(MessageType type, string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Message,
+                MessageVerbosityType = type,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogWarning(string message, params object[] messageArgs)
+        {
+            HasWarning = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Warning,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogWarning(string file, string message, params object[] messageArgs)
+        {
+            HasWarning = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Warning,
+                File = file,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void LogWarning(string file, int lineNumber, int linePosition, string message, params object[] messageArgs)
+        {
+            HasWarning = true;
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Warning,
+                File = file,
+                LineNumber = lineNumber,
+                LinePosition = linePosition,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void StartSection(string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageType = Section,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+        /// <summary>
+        /// Logging interface implementation.
+        /// </summary>
+        public void StartSection(MessageType type, string message, params object[] messageArgs)
+        {
+            Log.Add(new XdtTransformationLogEntry()
+            {
+                MessageVerbosityType = type,
+                MessageType = Section,
+                Message = message,
+                MessageArgs = messageArgs
+            });
+        }
+    }
+}

--- a/src/Cake.XdtTransform/XdtTransformationLogEntry.cs
+++ b/src/Cake.XdtTransform/XdtTransformationLogEntry.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Web.XmlTransform;
+using System;
+
+namespace Cake.XdtTransform
+{
+    /// <summary>
+    /// Entry from <see cref="XdtTransformationLogEntry"/>  
+    /// </summary>
+    public class XdtTransformationLogEntry
+    {
+        /// <summary>
+        /// Time of entry 
+        /// </summary>
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+
+        /// <summary>
+        ///  <see cref="Microsoft.Web.XmlTransform.MessageType"/> if supplied, depicts verbosity
+        /// </summary>
+        public MessageType? MessageVerbosityType { get; set; }
+
+        /// <summary>
+        /// MessageType, if supplied, i.e. "Message","Warning","Error" etc.
+        /// </summary>
+        public string MessageType { get; set; }
+
+        /// <summary>
+        /// File, if supplied
+        /// </summary>
+        public string File { get; set; }
+
+        /// <summary>
+        /// LineNumber, if supplied
+        /// </summary>
+        public int? LineNumber { get; set; }
+
+        /// <summary>
+        /// LinePosition, if supplied
+        /// </summary>
+        public int? LinePosition { get; set; }
+
+        /// <summary>
+        /// Exception, if supplied
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Message before format
+        /// </summary>
+        public string Message { get; set; } = "";
+
+        /// <summary>
+        /// Message arguments for format
+        /// </summary>
+        public object[] MessageArgs { get; set; } = new object[0];
+
+        /// <summary>
+        /// Outputs all available information as a string
+        /// </summary>
+        public override string ToString()
+        {
+            return $"[{Timestamp}] "
+                + FormatOrEmptyString(MessageType, () => $"[MessageType:{MessageType}] ")
+                + FormatOrEmptyString(MessageVerbosityType, () => $"[MessageVerbosityType:{MessageVerbosityType}] ")
+                + FormatOrEmptyString(File, () => $"[File:{File}] ")               
+                + FormatOrEmptyString(LineNumber, () => $"[LineNumber:{LineNumber}] ")
+                + FormatOrEmptyString(LinePosition, () => $"[LinePosition:{LinePosition}] ")
+                + FormatOrEmptyString(Exception, () => $"Exception: {Exception.ToString()} ")
+                + FormatOrEmptyString(Message, () => string.Format(Message, MessageArgs));
+        }
+
+        private static string FormatOrEmptyString<T>(T item, Func<string> format)
+        {
+            if(item == null)
+            {
+                return "";
+            }
+
+            return format();
+        }
+
+    }
+}


### PR DESCRIPTION
The methods are needed, because logging is the only way to know, if there were any issues during the transformation process. 
For example, following transformation has a problem - a match will not be found for an element:
```
 <appSettings>
	<add key="this-is-missing" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/>
    </appSettings>
```
This is a sign of bad config hygiene - either the element transformation contains a mistake (i.e. a typo), or the original target element changed, and transformation was not updated. The only way to know about this problem, up to my knowledge, is to look for a warning being logged. Commit provides a way to run transformation with the final log being returned to be examined for any warnings. 