### PR TITLE
Allow to use same file for source and target

### DIFF
--- a/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
+++ b/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
@@ -1,13 +1,15 @@
-﻿using Cake.Core.IO;
+﻿using System.IO;
+using System.Text;
+using Cake.Core.IO;
 using Cake.Testing;
 using Cake.XdtTransform.Tests.Properties;
+using FluentAssertions;
 
 namespace Cake.XdtTransform.Tests.Fixtures {
-    internal sealed class XdtTransformationFixture
-    {
+    internal sealed class XdtTransformationFixture {
         public IFileSystem FileSystem { get; set; }
-        public FilePath SourceFile { get; set; } 
-        public FilePath TransformFile { get; set; } 
+        public FilePath SourceFile { get; set; }
+        public FilePath TransformFile { get; set; }
         public FilePath TargetFile { get; set; }
 
         public XdtTransformationFixture(bool sourceFileExists = true, bool transformFileExists = true, bool targetFileExists = false) {
@@ -15,25 +17,20 @@ namespace Cake.XdtTransform.Tests.Fixtures {
             var fileSystem = new FakeFileSystem(environment);
             fileSystem.CreateDirectory("/Working");
 
-            if (sourceFileExists)
-            {
+            if (sourceFileExists) {
                 var sourceFile = fileSystem.CreateFile("/Working/web.config").SetContent(Resources.XdtTransformation_SourceFile);
                 SourceFile = sourceFile.Path;
             }
 
-            if (transformFileExists)
-            {
+            if (transformFileExists) {
                 var transformFile = fileSystem.CreateFile("/Working/web.release.config").SetContent(Resources.XdtTramsformation_TransformFile);
                 TransformFile = transformFile.Path;
             }
 
-            if (targetFileExists)
-            {
+            if (targetFileExists) {
                 var targetFile = fileSystem.CreateFile("/Working/transformed.config").SetContent(Resources.XdtTransformation_TargetFile);
                 TargetFile = targetFile.Path;
-            }
-            else
-            {
+            } else {
                 TargetFile = "/Working/transformed.config";
             }
 
@@ -46,6 +43,15 @@ namespace Cake.XdtTransform.Tests.Fixtures {
 
         public XdtTransformationLog TransformConfigWithDefaultLogger() {
             return XdtTransformation.TransformConfigWithDefaultLogger(FileSystem, SourceFile, TransformFile, TargetFile);
+        }
+
+        public string GetTargetFileContent() {
+            var targetFile = FileSystem.GetFile(TargetFile);
+            targetFile.Exists.Should().BeTrue();
+            using (var transformedStream = targetFile.OpenRead())
+            using (var streamReader = new StreamReader(transformedStream, Encoding.UTF8)) {
+                return streamReader.ReadToEnd();
+            }
         }
     }
 }

--- a/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text;
-using Cake.Core.IO;
 using Cake.XdtTransform.Tests.Fixtures;
 using FluentAssertions;
 using Xunit;
@@ -83,40 +81,22 @@ namespace Cake.XdtTransform.Tests {
             fixture.TransformConfig();
 
             // Then
-            var transformedFile = fixture.FileSystem.GetFile(fixture.TargetFile);
-            transformedFile.Exists.Should().BeTrue();
-            string transformedString;
-            using (var transformedStream = transformedFile.OpenRead()) {
-                using (var streamReader = new StreamReader(transformedStream, Encoding.UTF8)) {
-                    transformedString = streamReader.ReadToEnd();
-                }
-            }
+            var transformedString = fixture.GetTargetFileContent();
             transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
         }
 
         [Fact]
-        public void ShouldTransformFileWithDefaultLogger()
-        {
+        public void ShouldTransformFileWithDefaultLogger() {
             // Given
-            var fixture = new XdtTransformationFixture
-            {
+            var fixture = new XdtTransformationFixture {
                 TargetFile = "/Working/transformed.config"
             };
 
             // When
-            var  log = fixture.TransformConfigWithDefaultLogger();
+            var log = fixture.TransformConfigWithDefaultLogger();
 
             // Then
-            var transformedFile = fixture.FileSystem.GetFile(fixture.TargetFile);
-            transformedFile.Exists.Should().BeTrue();
-            string transformedString;
-            using (var transformedStream = transformedFile.OpenRead())
-            {
-                using (var streamReader = new StreamReader(transformedStream, Encoding.UTF8))
-                {
-                    transformedString = streamReader.ReadToEnd();
-                }
-            }
+            var transformedString = fixture.GetTargetFileContent();
             transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
             transformedString.Should().NotContain("this-is-missing");
 
@@ -124,6 +104,20 @@ namespace Cake.XdtTransform.Tests {
             log.HasException.Should().BeFalse();
             log.HasWarning.Should().BeTrue();
             log.Log.Count.Should().Equals(15);
+        }
+
+        [Fact]
+        public void ShouldTransformFileWithDefaultLoggerIfSameSourceAndTarget() {
+            // Given
+            var fixture = new XdtTransformationFixture();
+            fixture.TargetFile = fixture.SourceFile;
+
+            // When
+            fixture.TransformConfigWithDefaultLogger();
+
+            // Then
+            var transformedString = fixture.GetTargetFileContent();
+            transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
         }
     }
 }

--- a/src/Cake.XdtTransform/XdtTransformation.cs
+++ b/src/Cake.XdtTransform/XdtTransformation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using Cake.Core;
 using Cake.Core.IO;
 using DotNet.Xdt;
@@ -38,8 +37,7 @@ namespace Cake.XdtTransform {
         /// <param name="sourceFile">Source config file.</param>
         /// <param name="transformFile">Tranformation to apply.</param>
         /// <param name="targetFile">Target config file.</param>
-        public static XdtTransformationLog TransformConfigWithDefaultLogger(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile)
-        {
+        public static XdtTransformationLog TransformConfigWithDefaultLogger(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
             var log = new XdtTransformationLog();
 
             TransformConfig(fileSystem, sourceFile, transformFile, targetFile, log);
@@ -47,15 +45,15 @@ namespace Cake.XdtTransform {
             return log;
         }
 
-            /// <summary>
-            /// Transforms config file.
-            /// </summary>
-            /// <param name="fileSystem">The filesystem.</param>
-            /// <param name="sourceFile">Source config file.</param>
-            /// <param name="transformFile">Tranformation to apply.</param>
-            /// <param name="targetFile">Target config file.</param>
-            /// <param name="logger">Logger for the transfomration process</param>
-            public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile, IXmlTransformationLogger logger = null) {
+        /// <summary>
+        /// Transforms config file.
+        /// </summary>
+        /// <param name="fileSystem">The filesystem.</param>
+        /// <param name="sourceFile">Source config file.</param>
+        /// <param name="transformFile">Tranformation to apply.</param>
+        /// <param name="targetFile">Target config file.</param>
+        /// <param name="logger">Logger for the transfomration process.</param>
+        public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile, IXmlTransformationLogger logger = null) {
             if (fileSystem == null) {
                 throw new ArgumentNullException(nameof(fileSystem), "File system is null.");
             }
@@ -65,24 +63,24 @@ namespace Cake.XdtTransform {
                sourceConfigFile = fileSystem.GetFile(sourceFile),
                transformConfigFile = fileSystem.GetFile(transformFile),
                targetConfigFile = fileSystem.GetFile(targetFile);
-            
-            using (Stream
-                sourceStream = sourceConfigFile.OpenRead(),
-                transformStream = transformConfigFile.OpenRead(),
-                targetStream = targetConfigFile.OpenWrite())
-            using (var document = new XmlTransformableDocument { PreserveWhitespace = true })
-            using (var transform = new XmlTransformation(transformStream, logger))
-            {
-                document.Load(sourceStream);
 
-                if (!transform.Apply(document))
-                {
-                    throw new CakeException(
-                        $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
-                        );
+            using (var document = new XmlTransformableDocument {PreserveWhitespace = true}) {
+                using (var sourceStream = sourceConfigFile.OpenRead()) {
+                    document.Load(sourceStream);
                 }
 
-                document.Save(targetStream);
+                using (var transformStream = transformConfigFile.OpenRead())
+                using (var transform = new XmlTransformation(transformStream, logger)) {
+                    if (!transform.Apply(document)) {
+                        throw new CakeException(
+                            $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
+                            );
+                    }
+                }
+
+                using (var targetStream = targetConfigFile.OpenWrite()) {
+                    document.Save(targetStream);
+                }
             }
         }
 


### PR DESCRIPTION
I'm not sure if it's intentional: `TransformConfigWithDefaultLogger` unlike `TransformConfig` (the one without logger parameter) fails when source and target are the same file. This PR addresses this by changing the scope of the usings.
