### PR TITLE
Update README: Add link to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ Task("Transform-all-configs")
         }
     });
 ```
+
+## Discussion
+
+For questions and to discuss ideas & feature requests, use the [GitHub discussions on the Cake GitHub repository](https://github.com/cake-build/cake/discussions), under the [Extension Q&A](https://github.com/cake-build/cake/discussions/categories/extension-q-a) category.
+
+[![Join in the discussion on the Cake repository](https://img.shields.io/badge/GitHub-Discussions-green?logo=github)](https://github.com/cake-build/cake/discussions)


### PR DESCRIPTION
Hey @phillipsj, we've started using [GitHub Discussions](https://github.com/cake-build/cake/discussions) as the preferred communication channel moving forward (instead of Gitter) because it makes it easier to keep track of discussions in a structured way, especially if multiple discussions are happening at the same time. It also allows to search for previous questions/answers, which can be a helpful resource.

As such, we're recommending addin maintainers to update any links to Gitter to point to the GH discussions (you may have seen [this PR I sent to your Cake.Netlify addin](https://github.com/cake-contrib/Cake.Netlify/pull/14) already).

You didn't have any links on this repo, so I thought I'd send you a PR to include the template we're using, in case you think it's a good idea.

Cheers!

![image](https://user-images.githubusercontent.com/177608/105936595-5bcd3480-602a-11eb-99d4-095f2bdb64a3.png)
