### PR TITLE
GH-46: Add support for ad hoc XML transformations

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -20,7 +20,7 @@ ToolSettings.SetToolSettings(context: Context,
                             buildMSBuildToolVersion : MSBuildToolVersion.VS2017,
                             dupFinderExcludePattern: new string[] {
                                 BuildParameters.RootDirectoryPath + "/src/Cake.XdtTransform.Tests/*.cs" },
-                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[DotNet.Xdt]* -[FluentAssertions]*",
+                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[DotNet.Xdt]* -[FluentAssertions]* -[Moq]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs;*/Microsoft.Build.Framework.Version.cs");
 Build.RunDotNetCore();

--- a/src/Cake.XdtTransform.Tests/Cake.XdtTransform.Tests.csproj
+++ b/src/Cake.XdtTransform.Tests/Cake.XdtTransform.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="DotNet.Xdt" Version="2.2.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -22,6 +23,21 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Cake.XdtTransform\Cake.XdtTransform.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
+++ b/src/Cake.XdtTransform.Tests/Fixtures/XdtTransformationFixture.cs
@@ -8,9 +8,15 @@ using FluentAssertions;
 namespace Cake.XdtTransform.Tests.Fixtures {
     internal sealed class XdtTransformationFixture {
         public IFileSystem FileSystem { get; set; }
+        
         public FilePath SourceFile { get; set; }
+        
         public FilePath TransformFile { get; set; }
+        
         public FilePath TargetFile { get; set; }
+        
+        public XdtFileSource TransformFileSource { get; set; }
+
 
         public XdtTransformationFixture(bool sourceFileExists = true, bool transformFileExists = true, bool targetFileExists = false) {
             var environment = FakeEnvironment.CreateUnixEnvironment();
@@ -23,8 +29,10 @@ namespace Cake.XdtTransform.Tests.Fixtures {
             }
 
             if (transformFileExists) {
-                var transformFile = fileSystem.CreateFile("/Working/web.release.config").SetContent(Resources.XdtTramsformation_TransformFile);
+                var transformFile = fileSystem.CreateFile("/Working/web.release.config").SetContent(Resources.XdtTransformation_TransformFile);
                 TransformFile = transformFile.Path;
+
+                TransformFileSource = new XdtFileSource(fileSystem.GetFile(TransformFile));
             }
 
             if (targetFileExists) {
@@ -43,6 +51,18 @@ namespace Cake.XdtTransform.Tests.Fixtures {
 
         public XdtTransformationLog TransformConfigWithDefaultLogger() {
             return XdtTransformation.TransformConfigWithDefaultLogger(FileSystem, SourceFile, TransformFile, TargetFile);
+        }
+
+        public void TransformConfig(FilePath sourceFile, FilePath transformFile, FilePath targetFile, XdtTransformationSettings settings) {
+	        new XdtTransformation(FileSystem).TransformConfig(sourceFile, transformFile, targetFile, settings);
+        }
+
+        public void TransformConfig(FilePath sourceFile, FilePath targetFile, XdtSource transformation, XdtTransformationSettings settings) {
+	        new XdtTransformation(FileSystem).TransformConfig(sourceFile, targetFile, transformation, settings);
+        }
+
+        public void TransformConfig(XdtSource source, XdtTransformationSettings settings) {
+	        new XdtTransformation(FileSystem).TransformConfig(SourceFile, TargetFile, source, settings);
         }
 
         public string GetTargetFileContent() {

--- a/src/Cake.XdtTransform.Tests/Properties/Resources.Designer.cs
+++ b/src/Cake.XdtTransform.Tests/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Cake.XdtTransform.Tests.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,20 +61,15 @@ namespace Cake.XdtTransform.Tests.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot;?&gt;
-        ///&lt;configuration xmlns:xdt=&quot;http://schemas.microsoft.com/XML-Document-Transform&quot;&gt;
-        ///    &lt;appSettings&gt;
+        ///   Looks up a localized string similar to &lt;appSettings&gt;
         ///        &lt;add key=&quot;transformed&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
         ///	&lt;add key=&quot;this-is-missing&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
         ///    &lt;/appSettings&gt;
-        ///  &lt;system.web&gt;
-        ///    &lt;compilation xdt:Transform=&quot;RemoveAttributes(debug)&quot; /&gt;
-        ///  &lt;/system.web&gt;
-        ///&lt;/configuration&gt;.
+        ///.
         /// </summary>
-        internal static string XdtTramsformation_TransformFile {
+        internal static string XdtTransformation_DocumentFragment {
             get {
-                return ResourceManager.GetString("XdtTramsformation_TransformFile", resourceCulture);
+                return ResourceManager.GetString("XdtTransformation_DocumentFragment", resourceCulture);
             }
         }
         
@@ -87,7 +82,7 @@ namespace Cake.XdtTransform.Tests.Properties {
         ///&lt;configuration&gt;
         ///  &lt;configSections&gt;
         ///    &lt;!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --&gt;
-        ///    &lt;section name=&quot;entityFramework&quot; type=&quot;System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyTok [rest of string was truncated]&quot;;.
+        ///    &lt;section name=&quot;entityFramework&quot; type=&quot;System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string XdtTransformation_SourceFile {
             get {
@@ -104,11 +99,29 @@ namespace Cake.XdtTransform.Tests.Properties {
         ///&lt;configuration&gt;
         ///  &lt;configSections&gt;
         ///    &lt;!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --&gt;
-        ///    &lt;section name=&quot;entityFramework&quot; type=&quot;System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyTok [rest of string was truncated]&quot;;.
+        ///    &lt;section name=&quot;entityFramework&quot; type=&quot;System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string XdtTransformation_TargetFile {
             get {
                 return ResourceManager.GetString("XdtTransformation_TargetFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot;?&gt;
+        ///&lt;configuration xmlns:xdt=&quot;http://schemas.microsoft.com/XML-Document-Transform&quot;&gt;
+        ///    &lt;appSettings&gt;
+        ///        &lt;add key=&quot;transformed&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
+        ///	&lt;add key=&quot;this-is-missing&quot; value=&quot;false&quot; xdt:Transform=&quot;SetAttributes&quot; xdt:Locator=&quot;Match(key)&quot;/&gt;
+        ///    &lt;/appSettings&gt;
+        ///  &lt;system.web&gt;
+        ///    &lt;compilation xdt:Transform=&quot;RemoveAttributes(debug)&quot; /&gt;
+        ///  &lt;/system.web&gt;
+        ///&lt;/configuration&gt;.
+        /// </summary>
+        internal static string XdtTransformation_TransformFile {
+            get {
+                return ResourceManager.GetString("XdtTransformation_TransformFile", resourceCulture);
             }
         }
     }

--- a/src/Cake.XdtTransform.Tests/Properties/Resources.resx
+++ b/src/Cake.XdtTransform.Tests/Properties/Resources.resx
@@ -117,17 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="XdtTramsformation_TransformFile" xml:space="preserve">
-    <value>&lt;?xml version="1.0"?&gt;
-&lt;configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"&gt;
-    &lt;appSettings&gt;
+  <data name="XdtTransformation_DocumentFragment" xml:space="preserve">
+    <value>&lt;appSettings&gt;
         &lt;add key="transformed" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
 	&lt;add key="this-is-missing" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
     &lt;/appSettings&gt;
-  &lt;system.web&gt;
-    &lt;compilation xdt:Transform="RemoveAttributes(debug)" /&gt;
-  &lt;/system.web&gt;
-&lt;/configuration&gt;</value>
+</value>
   </data>
   <data name="XdtTransformation_SourceFile" xml:space="preserve">
     <value>&lt;?xml version="1.0" encoding="utf-8"?&gt;
@@ -331,5 +326,17 @@
   &lt;/system.codedom&gt;
 &lt;/configuration&gt;
 &lt;!--ProjectGuid: 28591C5B-D9AF-4711-A816-DBEBB12A58FD--&gt;</value>
+  </data>
+  <data name="XdtTransformation_TransformFile" xml:space="preserve">
+    <value>&lt;?xml version="1.0"?&gt;
+&lt;configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform"&gt;
+    &lt;appSettings&gt;
+        &lt;add key="transformed" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
+	&lt;add key="this-is-missing" value="false" xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/&gt;
+    &lt;/appSettings&gt;
+  &lt;system.web&gt;
+    &lt;compilation xdt:Transform="RemoveAttributes(debug)" /&gt;
+  &lt;/system.web&gt;
+&lt;/configuration&gt;</value>
   </data>
 </root>

--- a/src/Cake.XdtTransform.Tests/XdtDocumentSourceTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtDocumentSourceTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Cake.XdtTransform.Tests {
+  public sealed class XdtDocumentSourceTests {
+    public sealed class TheCtor {
+      [Theory]
+      [InlineData("")]
+      [InlineData("\t")]
+      [InlineData(null)]
+      public void ShouldThrowOnNullOrWhitespaceDocumentXml(string documentXml) {
+        var ex = Record.Exception(() => new XdtDocumentSource(documentXml));
+        ex.Should().BeOfType<ArgumentException>().Which.ParamName.Should().Be(nameof(documentXml));
+      }
+    }
+
+    public sealed class TheGetStreamMethod {
+      const string sourceTransformationXml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+  <appSettings>
+    <add key=""key-name"" value=""key-value"" xdt:Locator=""Match(key)"" xdt:Transform=""SetAttributes"" />    
+  </appSettings>
+</configuration>";
+
+      [Fact]
+      public void ShouldReturnStreamContainingXmlDocument() {
+        using var stream = new XdtDocumentSource(sourceTransformationXml).GetXdtStream();
+        using var reader = new StreamReader(stream);
+
+        var streamXml = reader.ReadToEnd();
+
+        streamXml.Should().Be(sourceTransformationXml, "because the xml string should roundtrip successfully");
+      }
+    }
+  }
+}

--- a/src/Cake.XdtTransform.Tests/XdtFileSourceTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtFileSourceTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using Cake.Core.IO;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Cake.XdtTransform.Tests {
+  public sealed class XdtFileSourceTests {
+    public sealed class TheCtor {
+      [Fact]
+      public void ShouldThrowOnNullFile() {
+        var ex = Record.Exception(() => new XdtFileSource(null));
+        ex.Should().BeOfType<ArgumentNullException>();
+      }
+    }
+
+    public sealed class TheGetStreamMethod {
+      [Fact]
+      public void ShouldReturnFileStream() {
+        var mockFile = new Mock<IFile>();
+        mockFile.Setup(x => x.Open(FileMode.Open, FileAccess.Read, FileShare.Read)).Returns(new MemoryStream(new byte[] {1, 2, 3}));
+
+        using var stream = new XdtFileSource(mockFile.Object).GetXdtStream();
+        
+        var bytes = new byte[3];
+        stream.Read(bytes, 0, (int)stream.Length);
+
+        stream.Length.Should().Be(3);
+        bytes.Should().BeEquivalentTo(new byte[] {1, 2, 3}, "because the file should have returned our exact mocked stream");
+      }
+    }
+  }
+}

--- a/src/Cake.XdtTransform.Tests/XdtFragmentSourceTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtFragmentSourceTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Cake.XdtTransform.Tests {
+  public sealed class XdtFragmentSourceTests {
+    public sealed class TheCtor {
+      [Theory]
+      [InlineData("")]
+      [InlineData("\t")]
+      [InlineData(null)]
+      public void ShouldThrowOnNullOrWhitespaceDocumentXml(string documentFragment) {
+        var ex = Record.Exception(() => new XdtFragmentSource(documentFragment));
+        ex.Should().BeOfType<ArgumentException>().Which.ParamName.Should().Be(nameof(documentFragment));
+      }
+    }
+
+    public sealed class TheGetStreamMethod {
+      const string ExpectedXml = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+  <appSettings>
+    <add key=""key-name"" value=""key-value"" xdt:Locator=""Match(key)"" xdt:Transform=""SetAttributes"" />    
+  </appSettings>
+</configuration>";
+
+      private const string DocumentFragment = @"<appSettings>
+    <add key=""key-name"" value=""key-value"" xdt:Locator=""Match(key)"" xdt:Transform=""SetAttributes"" />    
+  </appSettings>";
+
+      [Fact]
+      public void ShouldReturnStreamFromFragment() {
+        using var stream = new XdtFragmentSource(DocumentFragment).GetXdtStream();
+        using var reader = new StreamReader(stream);
+
+        var streamXml = reader.ReadToEnd();
+
+        streamXml.Should().Be(ExpectedXml, "because the document fragment should be expanded to be a valid, complete XDT document string.");
+      }
+
+      [Fact]
+      public void ShouldReturnStreamFromDocument() {
+        const string xmlDocument = @"<?xml version=""1.0"" encoding=""utf-8"" ?><foo xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform""/>";
+        
+        using var stream = new XdtFragmentSource(xmlDocument).GetXdtStream();
+        using var reader = new StreamReader(stream);
+
+        var streamXml = reader.ReadToEnd();
+
+        streamXml.Should().Be(xmlDocument, "because the document string should validate as good XML and be returned as-is.");
+      }
+
+      [Fact]
+      public void ShouldThrowIfDocumentIsNotValid() {
+        // this should fail because the namespace is not defined correctly.
+        // we should try the first check, attempt to wrap the fragment, and ultimately throw.
+        const string badXml = @"<appSettings><add key=""key-name"" value=""key-value"" badns:Locator=""Match(key)"" badns:Transform=""SetAttributes"" /></appSettings>";
+
+        var ex = Record.Exception(() => new XdtFragmentSource(badXml).GetXdtStream());
+        ex.Should().BeOfType<InvalidOperationException>();
+      }
+    }
+  }
+}

--- a/src/Cake.XdtTransform.Tests/XdtTransformationSettingsTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationSettingsTests.cs
@@ -1,0 +1,44 @@
+﻿using DotNet.Xdt;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Cake.XdtTransform.Tests {
+  public sealed class XdtTransformationSettingsTests {
+    public sealed class TheCtor {
+      [Fact]
+      public void ShouldInitializeLoggerToNull() {
+        new XdtTransformationSettings().Logger.Should().BeNull("because the logger should be initialized to null");
+      }
+    }
+
+    public sealed class TheUseDefaultLoggerMethod {
+      [Fact]
+      public void ShouldUseTheCorrectLoggerType() {
+        var subject = new XdtTransformationSettings().UseDefaultLogger();
+        subject.Logger.Should().BeOfType<XdtTransformationLog>($"because the logger should be set as the default {nameof(XdtTransformationLog)} type.");
+      }
+    }
+
+    public sealed class TheUseLoggerMethod {
+      [Fact]
+      public void ShouldAcceptNull() {
+        var subject = new XdtTransformationSettings();
+        var ex = Record.Exception(() => subject.UseLogger(null));
+
+        ex.Should().BeNull($"because no exception should be thrown when using a null {nameof(IXmlTransformationLogger)}");
+        subject.Logger.Should().BeNull();
+      }
+
+      [Fact]
+      public void ShouldSetTheLoggerCorrectly() {
+        var mockLogger = Mock.Of<IXmlTransformationLogger>();
+        var subject = new XdtTransformationSettings();
+
+        subject.UseLogger(mockLogger);
+
+        subject.Logger.Should().BeSameAs(mockLogger, "because the logger should have been set correctly");
+      }
+    }
+  }
+}

--- a/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
@@ -1,123 +1,259 @@
 ﻿using System;
 using System.IO;
+using Cake.Core.IO;
 using Cake.XdtTransform.Tests.Fixtures;
+using Cake.XdtTransform.Tests.Properties;
 using FluentAssertions;
 using Xunit;
 
 namespace Cake.XdtTransform.Tests {
     public sealed class XdtTransformationTests {
-        [Fact]
-        public void ShouldErrorIfSourceFileIsNull() {
-            // Given
-            var fixture = new XdtTransformationFixture {SourceFile = null};
 
-            // When
-            var result = Record.Exception(() => fixture.TransformConfig());
+        public sealed class TheCtor {
+            [Fact]
+            public void ShouldThrowIfFileSystemIsNull() {
+                var ex = Record.Exception(() => new XdtTransformation(null));
 
-            // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("sourceFile");
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("fileSystem");
+            }
         }
 
-        [Fact]
-        public void ShouldErrorIfTransformFileIsNull() {
-            // Given
-            var fixture = new XdtTransformationFixture {TransformFile = null};
+        public sealed class TheStaticMethods {
+            [Fact]
+            public void ShouldErrorIfSourceFileIsNull() {
+                // Given
+                var fixture = new XdtTransformationFixture { SourceFile = null };
 
-            // When
-            var result = Record.Exception(() => fixture.TransformConfig());
+                // When
+                var result = Record.Exception(() => fixture.TransformConfig());
 
-            // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("transformFile");
+                // Then
+                result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("sourceFile");
+            }
+
+            [Fact]
+            public void ShouldErrorIfTransformFileIsNull() {
+                // Given
+                var fixture = new XdtTransformationFixture { TransformFile = null };
+
+                // When
+                var result = Record.Exception(() => fixture.TransformConfig());
+
+                // Then
+                result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("transformFile");
+            }
+
+            [Fact]
+            public void ShouldErrorIfTargetFileIsNull() {
+                // Given
+                var fixture = new XdtTransformationFixture { TargetFile = null };
+
+                // When
+                var result = Record.Exception(() => fixture.TransformConfig());
+
+                // Then
+                result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("targetFile");
+            }
+
+            [Fact]
+            public void ShouldErrorIfSourceFileNotExists() {
+                // Given
+                var fixture = new XdtTransformationFixture(sourceFileExists: false)
+                {
+                    SourceFile = "/Working/non-existing.config"
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.TransformConfig());
+
+                // Then
+                result.Should().BeOfType<FileNotFoundException>().Subject.Message.Should().Contain("Unable to find the specified file.");
+            }
+
+            [Fact]
+            public void ShouldErrorIfTransformFileNotExists() {
+                // Given
+                var fixture = new XdtTransformationFixture(transformFileExists: false)
+                {
+                    TransformFile = "/Working/non-existing-transform.config"
+                };
+
+                // When
+                var result = Record.Exception(() => fixture.TransformConfig());
+
+                // Then
+                result.Should().BeOfType<FileNotFoundException>().Subject.Message.Should().Contain("Unable to find the specified file.");
+            }
+
+            [Fact]
+            public void ShouldTransformFile() {
+                // Given
+                var fixture = new XdtTransformationFixture
+                {
+                    TargetFile = "/Working/transformed.config"
+                };
+
+                // When
+                fixture.TransformConfig();
+
+                // Then
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
+
+            [Fact]
+            public void ShouldTransformFileWithDefaultLogger() {
+                // Given
+                var fixture = new XdtTransformationFixture
+                {
+                    TargetFile = "/Working/transformed.config"
+                };
+
+                // When
+                var log = fixture.TransformConfigWithDefaultLogger();
+
+                // Then
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+                transformedString.Should().NotContain("this-is-missing");
+
+                log.HasError.Should().BeFalse();
+                log.HasException.Should().BeFalse();
+                log.HasWarning.Should().BeTrue();
+                log.Log.Count.Should().Be(15);
+            }
+
+            [Fact]
+            public void ShouldTransformFileWithDefaultLoggerIfSameSourceAndTarget() {
+                // Given
+                var fixture = new XdtTransformationFixture();
+                fixture.TargetFile = fixture.SourceFile;
+
+                // When
+                fixture.TransformConfigWithDefaultLogger();
+
+                // Then
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
         }
 
-        [Fact]
-        public void ShouldErrorIfTargetFileIsNull() {
-            // Given
-            var fixture = new XdtTransformationFixture {TargetFile = null};
+        public sealed class TheTransformConfigUsingFileMethod {
+            [Fact]
+            public void ShouldThrowWhenSourceFileIsNull() {
+                var fixture = new XdtTransformationFixture();
 
-            // When
-            var result = Record.Exception(() => fixture.TransformConfig());
+                var ex = Record.Exception(() => fixture.TransformConfig(null, fixture.TransformFile, fixture.TargetFile, new XdtTransformationSettings()));
 
-            // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("targetFile");
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("sourceFile");
+            }
+
+            [Fact]
+            public void ShouldThrowWhenTransformFileIsNull() {
+                var fixture = new XdtTransformationFixture();
+
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, null, fixture.TargetFile, new XdtTransformationSettings()));
+
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("transformFile");
+            }
+            
+            [Fact]
+            public void ShouldThrowWhenTargetFileIsNull() {
+                var fixture = new XdtTransformationFixture();
+
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, fixture.TransformFile, (FilePath)null, new XdtTransformationSettings()));
+
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("targetFile");
+            }
+
+            [Fact]
+            public void ShouldThrowWhenSettingsIsNull() {
+                var fixture = new XdtTransformationFixture();
+
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, fixture.TransformFile, fixture.TargetFile, null));
+
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("settings");
+            }
+
+            [Fact]
+            public void ShouldTransformFile() {
+                var fixture = new XdtTransformationFixture { TargetFile = "/Working/transformed.config"};
+
+                fixture.TransformConfig(fixture.SourceFile, fixture.TransformFile, fixture.TargetFile, new XdtTransformationSettings());
+
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
         }
 
-        [Fact]
-        public void ShouldErrorIfSourceFileNotExists() {
-            // Given
-            var fixture = new XdtTransformationFixture(sourceFileExists: false) {
-                SourceFile = "/Working/non-existing.config"
-            };
+        public sealed class TheTransformConfigUsingXdtSourceMethod {
+            [Fact]
+            public void ShouldThrowWhenSourceFileIsNull() {
+                var fixture = new XdtTransformationFixture();
 
-            // When
-            var result = Record.Exception(() => fixture.TransformConfig());
+                var ex = Record.Exception(() => fixture.TransformConfig(null, fixture.TargetFile, fixture.TransformFileSource, new XdtTransformationSettings()));
 
-            // Then
-            result.Should().BeOfType<FileNotFoundException>().Subject.Message.Should().Contain("Unable to find the specified file.");
-        }
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("sourceFile");
+            }
 
-        [Fact]
-        public void ShouldErrorIfTransformFileNotExists() {
-            // Given
-            var fixture = new XdtTransformationFixture(transformFileExists: false) {
-                TransformFile = "/Working/non-existing-transform.config"
-            };
+            [Fact]
+            public void ShouldThrowWhenTargetFileIsNull() {
+                var fixture = new XdtTransformationFixture();
 
-            // When
-            var result = Record.Exception(() => fixture.TransformConfig());
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, null, fixture.TransformFileSource, new XdtTransformationSettings()));
 
-            // Then
-            result.Should().BeOfType<FileNotFoundException>().Subject.Message.Should().Contain("Unable to find the specified file.");
-        }
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("targetFile");
+            }
 
-        [Fact]
-        public void ShouldTransformFile() {
-            // Given
-            var fixture = new XdtTransformationFixture {
-                TargetFile = "/Working/transformed.config"
-            };
+            [Fact]
+            public void ShouldThrowWhenXdtTransformIsNull() {
+                var fixture = new XdtTransformationFixture();
 
-            // When
-            fixture.TransformConfig();
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, fixture.TargetFile, (XdtSource)null, new XdtTransformationSettings()));
 
-            // Then
-            var transformedString = fixture.GetTargetFileContent();
-            transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
-        }
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("transformation");
+            }
 
-        [Fact]
-        public void ShouldTransformFileWithDefaultLogger() {
-            // Given
-            var fixture = new XdtTransformationFixture {
-                TargetFile = "/Working/transformed.config"
-            };
+            [Fact]
+            public void ShouldThrowWhenSettingsIsNull() {
+                var fixture = new XdtTransformationFixture();
 
-            // When
-            var log = fixture.TransformConfigWithDefaultLogger();
+                var ex = Record.Exception(() => fixture.TransformConfig(fixture.SourceFile, fixture.TransformFile, fixture.TransformFileSource, null));
 
-            // Then
-            var transformedString = fixture.GetTargetFileContent();
-            transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
-            transformedString.Should().NotContain("this-is-missing");
+                ex.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("settings");
+            }
 
-            log.HasError.Should().BeFalse();
-            log.HasException.Should().BeFalse();
-            log.HasWarning.Should().BeTrue();
-            log.Log.Count.Should().Be(15);
-        }
+            [Fact]
+            public void ShouldTransformFileUsingXdtFileTransform() {
+                var fixture = new XdtTransformationFixture { TargetFile = "/Working/transformed.config" };
 
-        [Fact]
-        public void ShouldTransformFileWithDefaultLoggerIfSameSourceAndTarget() {
-            // Given
-            var fixture = new XdtTransformationFixture();
-            fixture.TargetFile = fixture.SourceFile;
+                fixture.TransformConfig(fixture.SourceFile, fixture.TargetFile, fixture.TransformFileSource, new XdtTransformationSettings());
 
-            // When
-            fixture.TransformConfigWithDefaultLogger();
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
 
-            // Then
-            var transformedString = fixture.GetTargetFileContent();
-            transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            [Fact]
+            public void ShouldTransformFileUsingXdtDocumentTransform() {
+                var fixture = new XdtTransformationFixture { TargetFile = "/Working/transformed.config" };
+
+                var transform = new XdtDocumentSource(Resources.XdtTransformation_TransformFile);
+                fixture.TransformConfig(fixture.SourceFile, fixture.TargetFile, transform, new XdtTransformationSettings());
+
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
+
+            [Fact]
+            public void ShouldTransformFileUsingXdtFragmentTransform() {
+                var fixture = new XdtTransformationFixture { TargetFile = "/Working/transformed.config" };
+
+                var transform = new XdtFragmentSource(Resources.XdtTransformation_DocumentFragment);
+                fixture.TransformConfig(fixture.SourceFile, fixture.TargetFile, transform, new XdtTransformationSettings());
+
+                var transformedString = fixture.GetTargetFileContent();
+                transformedString.Should().Contain("<add key=\"transformed\" value=\"false\"/>");
+            }
         }
     }
 }

--- a/src/Cake.XdtTransform/Properties/AssemblyInfo.cs
+++ b/src/Cake.XdtTransform/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Cake.XdtTransform.Tests")]

--- a/src/Cake.XdtTransform/XdtDocumentSource.cs
+++ b/src/Cake.XdtTransform/XdtDocumentSource.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Cake.XdtTransform {
+  /// <summary>
+  /// Represents a literal XDT transformation document.
+  /// </summary>
+  public sealed class XdtDocumentSource : XdtSource {
+    private readonly string _documentXml;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:XdtDocumentSource" /> class.
+    /// </summary>
+    /// <param name="documentXml">The XML document content.</param>
+    public XdtDocumentSource(string documentXml) {
+      if (string.IsNullOrWhiteSpace(documentXml)) {
+        throw new ArgumentException("Value cannot be null or whitespace.", nameof(documentXml));
+      }
+      _documentXml = documentXml;
+    }
+
+    /// <inheritdoc />
+    public override Stream GetXdtStream() {
+      var transformStream = new MemoryStream();
+      using (var writer = new StreamWriter(transformStream, new UTF8Encoding(false, true), 1024, true)) {
+        writer.Write(_documentXml);
+        writer.Flush();
+        transformStream.Position = 0;
+      }
+
+      return transformStream;
+    }
+  }
+}

--- a/src/Cake.XdtTransform/XdtFileSource.cs
+++ b/src/Cake.XdtTransform/XdtFileSource.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using Cake.Core.IO;
+
+namespace Cake.XdtTransform {
+  /// <summary>
+  /// Represents a XDT transformation XML document on the file system.
+  /// </summary>
+  internal sealed class XdtFileSource : XdtSource {
+    private readonly IFile _file;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:XdtFileSource" /> class.
+    /// </summary>
+    /// <param name="file">The file containing the transform document.</param>
+    public XdtFileSource(IFile file) {
+      _file = file ?? throw new ArgumentNullException(nameof(file));
+    }
+
+    /// <inheritdoc />
+    public override Stream GetXdtStream() {
+      return _file.OpenRead();
+    }
+  }
+}

--- a/src/Cake.XdtTransform/XdtFragmentSource.cs
+++ b/src/Cake.XdtTransform/XdtFragmentSource.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+
+namespace Cake.XdtTransform {
+
+  /// <summary>
+  /// Represents a fragment of an XDT transformation document.
+  /// <para>
+  /// This is typically going to be a document fragment like a single &lt;appSettings&gt; value as opposed to a full document.
+  /// </para>
+  /// <para>
+  /// The implementation will attempt to infer the correct document structure using the default .NET &lt;configuration&gt; root element.
+  /// For more complex use cases, it's probably most appropriate to use <see cref="XdtDocumentSource"/> or derive a class from <see cref="XdtSource"/>.
+  /// </para>
+  /// </summary>
+  /// <example>
+  /// <code>
+  /// var transform = "&lt;appSettings&gt;&lt;add key="key-name" value="key-value" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" /&gt;&lt;/appSettings&gt;";
+  /// var fragmentSource = new XdtFragmentSource(transform);
+  /// </code>
+  /// </example>
+  public sealed class XdtFragmentSource : XdtSource {
+    
+    private const string DocumentXmlFormat = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<configuration xmlns:xdt=""http://schemas.microsoft.com/XML-Document-Transform"">
+  {0}
+</configuration>";
+    private readonly string _documentFragment;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="T:XdtFileSource" /> class.
+    /// </summary>
+    /// <param name="documentFragment">The transformation XML fragment.</param>
+    public XdtFragmentSource(string documentFragment) {
+      if (string.IsNullOrWhiteSpace(documentFragment)) {
+        throw new ArgumentException("Value cannot be null or whitespace.", nameof(documentFragment));
+      }
+      _documentFragment = documentFragment;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Stream"/> representing the transformation document.
+    /// </summary>
+    /// <returns>The <see cref="Stream"/> representing the transformation document.</returns>
+    public override Stream GetXdtStream() {
+      // first check the fragment.  if it's valid, process it as a document.
+      if (this.IsValidXml(this._documentFragment)) {
+        return new XdtDocumentSource(this._documentFragment).GetXdtStream();
+      }
+
+      // now try formatting it.
+      var xmlDocument = string.Format(CultureInfo.InvariantCulture, DocumentXmlFormat, this._documentFragment);
+      if (this.IsValidXml(xmlDocument)) {
+        return new XdtDocumentSource(xmlDocument).GetXdtStream();
+      }
+
+      throw new InvalidOperationException("The document fragment cannot be converted to a valid XML document.  Unable to create a valid Xdt stream.");
+    }
+
+    private bool IsValidXml(string xmlDocument) {
+      // quick check - is it valid xml?  we need to check to avoid wrapping perfectly valid XML.
+      // i.e., if someone passed an entire document to the fragment constructor.
+      var document = new XmlDocument();
+      try {
+        document.LoadXml(xmlDocument);
+        return true;
+      }
+      catch {
+        return false;
+      }
+    }
+  }
+}

--- a/src/Cake.XdtTransform/XdtSource.cs
+++ b/src/Cake.XdtTransform/XdtSource.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+
+namespace Cake.XdtTransform
+{
+  /// <summary>
+  /// Represents the source of an XDT transformation XML document.
+  /// </summary>
+  public abstract class XdtSource {
+    /// <summary>
+    /// Gets the <see cref="Stream"/> representing the transformation document.
+    /// </summary>
+    /// <returns>The <see cref="Stream"/> representing the transformation document.</returns>
+    public abstract Stream GetXdtStream();
+  }
+}

--- a/src/Cake.XdtTransform/XdtTransformation.cs
+++ b/src/Cake.XdtTransform/XdtTransformation.cs
@@ -5,95 +5,154 @@ using DotNet.Xdt;
 
 namespace Cake.XdtTransform {
     /// <summary>
-    /// The XDT Transformatin class.
+    /// The XDT Transformation class.
     /// </summary>
-    public static class XdtTransformation {
-        /// <summary>
-        /// Transforms config file.
-        /// </summary>
-        /// <param name="sourceFile">Source config file.</param>
-        /// <param name="transformFile">Tranformation to apply.</param>
-        /// <param name="targetFile">Target config file.</param>
-        public static void TransformConfig(FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
-            CheckNulls(sourceFile, transformFile, targetFile);
-            using (var document = new XmlTransformableDocument {PreserveWhitespace = true})
-            using (var transform = new XmlTransformation(transformFile.ToString())) {
-                document.Load(sourceFile.ToString());
+    public sealed class XdtTransformation {
+    private readonly IFileSystem _fileSystem;
 
-                if (!transform.Apply(document)) {
-                    throw new CakeException(
-                        $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
-                        );
-                }
-
-                document.Save(targetFile.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Transforms config file and returns transformation log.
-        /// </summary>
-        /// <param name="fileSystem">The filesystem.</param>
-        /// <param name="sourceFile">Source config file.</param>
-        /// <param name="transformFile">Tranformation to apply.</param>
-        /// <param name="targetFile">Target config file.</param>
-        public static XdtTransformationLog TransformConfigWithDefaultLogger(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
-            var log = new XdtTransformationLog();
-
-            TransformConfig(fileSystem, sourceFile, transformFile, targetFile, log);
-
-            return log;
-        }
-
-        /// <summary>
-        /// Transforms config file.
-        /// </summary>
-        /// <param name="fileSystem">The filesystem.</param>
-        /// <param name="sourceFile">Source config file.</param>
-        /// <param name="transformFile">Tranformation to apply.</param>
-        /// <param name="targetFile">Target config file.</param>
-        /// <param name="logger">Logger for the transfomration process.</param>
-        public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile, IXmlTransformationLogger logger = null) {
-            if (fileSystem == null) {
-                throw new ArgumentNullException(nameof(fileSystem), "File system is null.");
-            }
-            CheckNulls(sourceFile, transformFile, targetFile);
-
-            IFile
-               sourceConfigFile = fileSystem.GetFile(sourceFile),
-               transformConfigFile = fileSystem.GetFile(transformFile),
-               targetConfigFile = fileSystem.GetFile(targetFile);
-
-            using (var document = new XmlTransformableDocument {PreserveWhitespace = true}) {
-                using (var sourceStream = sourceConfigFile.OpenRead()) {
-                    document.Load(sourceStream);
-                }
-
-                using (var transformStream = transformConfigFile.OpenRead())
-                using (var transform = new XmlTransformation(transformStream, logger)) {
-                    if (!transform.Apply(document)) {
-                        throw new CakeException(
-                            $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
-                            );
-                    }
-                }
-
-                using (var targetStream = targetConfigFile.OpenWrite()) {
-                    document.Save(targetStream);
-                }
-            }
-        }
-
-        private static void CheckNulls(FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
-            if (sourceFile == null) {
-                throw new ArgumentNullException(nameof(sourceFile), "Source file path is null.");
-            }
-            if (transformFile == null) {
-                throw new ArgumentNullException(nameof(transformFile), "Transform file path is null.");
-            }
-            if (targetFile == null) {
-                throw new ArgumentNullException(nameof(targetFile), "Target file path is null.");
-            }
-        }
+    /// <summary>Initializes a new instance of the <see cref="XdtTransformation"></see> class.</summary>
+    public XdtTransformation(IFileSystem fileSystem) {
+      _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
     }
+
+    /// <summary>
+    /// Transforms config file.
+    /// </summary>
+    /// <param name="sourceFile">Source config file.</param>
+    /// <param name="transformFile">Transformation to apply.</param>
+    /// <param name="targetFile">Target config file.</param>
+    public static void TransformConfig(FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
+      if (sourceFile == null) {
+        throw new ArgumentNullException(nameof(sourceFile), "Source file path is null.");
+      }
+      if (transformFile == null) {
+        throw new ArgumentNullException(nameof(transformFile), "Transform file path is null.");
+      }
+      if (targetFile == null) {
+        throw new ArgumentNullException(nameof(targetFile), "Target file path is null.");
+      }
+
+      using (var document = new XmlTransformableDocument { PreserveWhitespace = true })
+      using (var transform = new XmlTransformation(transformFile.ToString())) {
+        document.Load(sourceFile.ToString());
+
+        if (!transform.Apply(document)) {
+          throw new CakeException(
+            $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
+            );
+        }
+
+        document.Save(targetFile.ToString());
+      }
+    }
+
+    /// <summary>
+    /// Transforms config file and returns transformation log.
+    /// </summary>
+    /// <param name="fileSystem">The filesystem.</param>
+    /// <param name="sourceFile">Source config file.</param>
+    /// <param name="transformFile">Transformation to apply.</param>
+    /// <param name="targetFile">Target config file.</param>
+    public static XdtTransformationLog TransformConfigWithDefaultLogger(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile) {
+      var log = new XdtTransformationLog();
+
+      TransformConfig(fileSystem, sourceFile, transformFile, targetFile, log);
+
+      return log;
+    }
+
+    /// <summary>
+    /// Transforms config file.
+    /// </summary>
+    /// <param name="fileSystem">The filesystem.</param>
+    /// <param name="sourceFile">Source config file.</param>
+    /// <param name="transformFile">Transformation to apply.</param>
+    /// <param name="targetFile">Target config file.</param>
+    /// <param name="logger">Logger for the transformation process.</param>
+    public static void TransformConfig(IFileSystem fileSystem, FilePath sourceFile, FilePath transformFile, FilePath targetFile, IXmlTransformationLogger logger = null) {
+      // pass whatever logger we've received.
+      var settings = new XdtTransformationSettings().UseLogger(logger);
+      new XdtTransformation(fileSystem).TransformConfig(sourceFile, transformFile, targetFile, settings);
+    }
+
+    /// <summary>
+    /// Transforms config file.
+    /// </summary>
+    /// <param name="sourceFile">Source config file.</param>
+    /// <param name="transformFile">Transformation to apply.</param>
+    /// <param name="targetFile">Target config file.</param>
+    /// <param name="settings">The settings to use for the transformation.</param>
+    internal void TransformConfig(FilePath sourceFile, FilePath transformFile, FilePath targetFile, XdtTransformationSettings settings) {
+      if (sourceFile == null) {
+        throw new ArgumentNullException(nameof(sourceFile));
+      }
+      if (transformFile == null) {
+        throw new ArgumentNullException(nameof(transformFile));
+      }
+      if (targetFile == null) {
+        throw new ArgumentNullException(nameof(targetFile));
+      }
+      if (settings == null) {
+        throw new ArgumentNullException(nameof(settings));
+      }
+
+      void TransformUsingFile(XmlTransformableDocument document) {
+        var transformConfigFile = this._fileSystem.GetFile(transformFile);
+
+        using (var transformStream = transformConfigFile.OpenRead())
+        using (var transform = new XmlTransformation(transformStream, settings.Logger)) {
+          if (!transform.Apply(document)) {
+            throw new CakeException(
+              $"Failed to transform \"{sourceFile}\" using \"{transformFile}\" to \"{targetFile}\""
+            );
+          }
+        }
+      }
+
+      TransformConfig(sourceFile, targetFile, TransformUsingFile);
+    }
+
+    internal void TransformConfig(FilePath sourceFile, FilePath targetFile, XdtSource transformation, XdtTransformationSettings settings) {
+      if (sourceFile == null) {
+        throw new ArgumentNullException(nameof(sourceFile));
+      }
+      if (targetFile == null) {
+        throw new ArgumentNullException(nameof(targetFile));
+      }
+      if (transformation == null) {
+        throw new ArgumentNullException(nameof(transformation));
+      }
+      if (settings == null) {
+        throw new ArgumentNullException(nameof(settings));
+      }
+
+      void TransformUsingStream(XmlTransformableDocument document) {
+        using (var transform = new XmlTransformation(transformation.GetXdtStream(), settings.Logger)) {
+          if (!transform.Apply(document)) {
+            throw new CakeException($"Failed to transform \"{sourceFile}\" to \"{targetFile}\"");
+          }
+        }
+      }
+
+      TransformConfig(sourceFile, targetFile, TransformUsingStream);
+    }
+
+    private void TransformConfig(FilePath sourceFile, FilePath targetFile, Action<XmlTransformableDocument> transformation) {
+      IFile
+        sourceConfigFile = this._fileSystem.GetFile(sourceFile),
+        targetConfigFile = this._fileSystem.GetFile(targetFile);
+
+      using (var document = new XmlTransformableDocument { PreserveWhitespace = true }) {
+        using (var sourceStream = sourceConfigFile.OpenRead()) {
+          document.Load(sourceStream);
+        }
+
+        transformation(document);
+
+        using (var targetStream = targetConfigFile.OpenWrite()) {
+          document.Save(targetStream);
+        }
+      }
+    }
+  }
 }

--- a/src/Cake.XdtTransform/XdtTransformationAlias.cs
+++ b/src/Cake.XdtTransform/XdtTransformationAlias.cs
@@ -124,5 +124,184 @@ namespace Cake.XdtTransform {
             }
             return XdtTransformation.TransformConfigWithDefaultLogger(context.FileSystem, sourceFile, transformFile, targetFile);
         }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        /// 
+        ///     var sourceFile = File("web.config");
+        ///     var transformFile = File("web.release.config");
+        ///     var settings = new XdtTransformationSettings().UseDefaultLogger();
+        ///
+        ///     XdtTransformConfig(sourceFile, transformFile, settings);
+        ///     
+        ///     if(settings.Logger.HasWarning)
+        ///     {
+        ///         var warnings = settings.Logger.Log
+        ///                           .Where(entry => entry.MessageType == XdtTransformationLog.Warning)
+        ///                           .Select(entry => entry.ToString());
+        ///                           
+        ///         var concatWarnings = string.Join("\r\n", warnings);
+        ///         
+        ///         throw new Exception("Transformation has warnings:\r\n" + concatWarnings);
+        ///     }
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.  This is also the target file, indicating an in-place transform.</param>
+        /// <param name="transformFile">The transformation to apply.</param>
+        /// <param name="settings">The settings to use during transformation.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        public static void XdtTransformConfig(this ICakeContext context, FilePath sourceFile, FilePath transformFile, XdtTransformationSettings settings) {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            new XdtTransformation(context.FileSystem).TransformConfig(sourceFile, transformFile, sourceFile, settings);
+        }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        /// 
+        ///     var sourceFile = File("web.config");
+        ///     var transformFile = File("web.release.config");
+        ///     var targetFile = File("web.target.config");
+        ///     var settings = new XdtTransformationSettings().UseDefaultLogger();
+        ///
+        ///     XdtTransformConfig(sourceFile, transformFile, targetFile, settings);
+        ///     
+        ///     if(settings.Logger.HasWarning)
+        ///     {
+        ///         var warnings = settings.Logger.Log
+        ///                           .Where(entry => entry.MessageType == XdtTransformationLog.Warning)
+        ///                           .Select(entry => entry.ToString());
+        ///                           
+        ///         var concatWarnings = string.Join("\r\n", warnings);
+        ///         
+        ///         throw new Exception("Transformation has warnings:\r\n" + concatWarnings);
+        ///     }
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.</param>
+        /// <param name="transformFile">The transformation to apply.</param>
+        /// <param name="targetFile">Output file name for the transformed file.</param>
+        /// <param name="settings">The settings to use during transformation.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        public static void XdtTransformConfig(this ICakeContext context, FilePath sourceFile, FilePath transformFile, FilePath targetFile, XdtTransformationSettings settings) {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            new XdtTransformation(context.FileSystem).TransformConfig(sourceFile, transformFile, targetFile, settings);
+        }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library using the specified transformation source.  The transformation source can be a file, a transform document, or a document fragment.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        ///
+        ///     var transformFragment = "&lt;appSettings&gt;&lt;add key="key-name" value="key-value" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" /&gt;&lt;/appSettings&gt;";
+        ///     var sourceFile = File("web.config");
+        ///     var settings = new XdtTransformationSettings().UseDefaultLogger();
+        ///
+        ///     XdtTransformConfig(sourceFile, new XdtFragmentSource(transformFragment), settings);
+        ///     
+        ///     if(settings.Logger.HasWarning)
+        ///     {
+        ///         var warnings = settings.Logger.Log
+        ///                           .Where(entry => entry.MessageType == XdtTransformationLog.Warning)
+        ///                           .Select(entry => entry.ToString());
+        ///                           
+        ///         var concatWarnings = string.Join("\r\n", warnings);
+        ///         
+        ///         throw new Exception("Transformation has warnings:\r\n" + concatWarnings);
+        ///     }
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.  This is also the target file, indicating an in-place transform.</param>
+        /// <param name="transformation">The transformation to apply.</param>
+        /// <param name="settings">The settings to use during transformation.  Specifying <c>null</c> will throw any errors encountered.</param>
+        [CakeMethodAlias]
+        public static void XdtTransformConfig(this ICakeContext context, FilePath sourceFile, XdtSource transformation, XdtTransformationSettings settings = null) {
+            XdtTransformConfig(context, sourceFile, sourceFile, transformation, settings);
+        }
+
+        /// <summary>
+        /// Transforms configuration files using XDT Transform library using the specified transformation source.  The transformation source can be a file, a transform document, or a document fragment.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var target = Argument("target", "Default");
+        ///
+        /// Task("TransformConfig")
+        ///   .Does(() => {
+        ///
+        ///     // specifying a fragment like this will infer and create a full document XML structure.
+        ///     // use XdtDocumentSource to pass a fully qualified XML document structure
+        ///     var transformFragment = "&lt;appSettings&gt;&lt;add key="key-name" value="key-value" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" /&gt;&lt;/appSettings&gt;";
+        ///     var sourceFile = File("web.config");
+        ///     var targetFile = File("web.target.config");
+        ///     var settings = new XdtTransformationSettings().UseDefaultLogger();
+        ///
+        ///     XdtTransformConfig(sourceFile, targetFile, new XdtFragmentSource(transformFragment), settings);
+        ///     
+        ///     if(settings.Logger.HasWarning)
+        ///     {
+        ///         var warnings = settings.Logger.Log
+        ///                           .Where(entry => entry.MessageType == XdtTransformationLog.Warning)
+        ///                           .Select(entry => entry.ToString());
+        ///                           
+        ///         var concatWarnings = string.Join("\r\n", warnings);
+        ///         
+        ///         throw new Exception("Transformation has warnings:\r\n" + concatWarnings);
+        ///     }
+        /// });
+        ///
+        /// RunTarget(target);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="sourceFile">Source file to be transformed.</param>
+        /// <param name="targetFile">Output file name for the transformed file.</param>
+        /// <param name="transformation">The transformation to apply.</param>
+        /// <param name="settings">The settings to use during transformation.  Specifying <c>null</c> will throw any errors encountered.</param>
+        [CakeMethodAlias]
+        public static void XdtTransformConfig(this ICakeContext context, FilePath sourceFile, FilePath targetFile, XdtSource transformation, XdtTransformationSettings settings = null) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+            new XdtTransformation(context.FileSystem).TransformConfig(sourceFile, targetFile, transformation, settings ?? new XdtTransformationSettings());
+        }
     }
 }

--- a/src/Cake.XdtTransform/XdtTransformationSettings.cs
+++ b/src/Cake.XdtTransform/XdtTransformationSettings.cs
@@ -1,0 +1,35 @@
+﻿using DotNet.Xdt;
+
+namespace Cake.XdtTransform {
+  /// <summary>
+  /// Contains settings used by <see cref="XdtTransformation"/>.
+  /// </summary>
+  public sealed class XdtTransformationSettings {
+    /// <summary>
+    /// Gets or sets the <see cref="IXmlTransformationLogger"/> to use while performing transformations.
+    /// </summary>
+    /// <remarks>
+    /// If set to <c>null</c>, the default implementation will throw any exceptions that are logged.
+    /// </remarks>
+    public IXmlTransformationLogger Logger { get; internal set; }
+
+    /// <summary>
+    /// Sets the logger to use the default implementation of <see cref="XdtTransformationLog"/>.
+    /// </summary>
+    /// <returns>The same <see cref="XdtTransformationSettings"/> instance so that multiple calls can be chained.</returns>
+    public XdtTransformationSettings UseDefaultLogger() {
+      this.Logger = new XdtTransformationLog();
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the logger to use a specific instance of <see cref="IXmlTransformationLogger"/> or <c>null</c>.
+    /// </summary>
+    /// <param name="logger">The <see cref="IXmlTransformationLogger"/> to use, or <c>null</c> to specify that any exceptions should be thrown.</param>
+    /// <returns>The same <see cref="XdtTransformationSettings"/> instance so that multiple calls can be chained.</returns>
+    public XdtTransformationSettings UseLogger(IXmlTransformationLogger logger) {
+      this.Logger = logger;
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
`DO NOT MERGE`

This is raw & extremely WIP.  I am putting this up for some general thoughts on how I've approached it.

I think this is a great improvement to the API of this extension, but I'll admit to being a little biased about this change 😃
To that end, I typically don't care for varying names/return types to express the calling conventions; overloads or refactors have a way of blurring that meaning and the names become less clear.  Probably not the case for this extension, but something I've tried to keep in mind when thinking about how I, as a developer/consumer, want to invoke the aliases we're exposing here.

To that end, I've taken what's already there, the core of it, and refactored toward extensible objects.
In order to converge the implementations to a common invocation, I've introduced a couple of changes.

```csharp
abstract class XdtSource
{
  abstract Stream GetXdtStream();
}
```

This type hierarchy can be extended to `FilePath`, full XML document streams, or any intermediate.  All the object has to do is provide a stream that can be consumed by `XmlTransformation` .. i.e., 
```csharp
// local function, just citing the example
void TransformUsingStream(XmlTransformableDocument document) {
  using (var transform = new XmlTransformation(transformation.GetXdtStream(), settings.Logger)) {
      if (!transform.Apply(document)) {
          throw new CakeException($"Failed to transform \"{sourceFile}\" to \"{targetFile}\"");
      }
  }
}
```

The other change I've made is adding `XdtTransformationSettings` to express the modes of `IXmlTransformationLogger` that are currently employed.

| Logger  | Error Action |
| ------------- | ------------- |
| `null`  | Behavior consistent with the current optional parameter `IXmlTransformationLogger logger = null`  |
| `UseDefaultLogger()` | Default behavior consistent with the current implementation of `XdtTransformConfigWithDefaultLogger`|
| `UseLogger(IXmlTransformationLogger logger)` | Custom behavior defined by implementation| 

The real intent and power of the pattern is that we don't have to create additional named overloads to modify the way in which the aliases can be called.  It's really just a matter of reading the reference you've already got to the logger.
```csharp
var fragment = @"<appSettings>
    <add key=""key-name"" value=""key-value"" xdt:Locator=""Match(key)"" xdt:Transform=""SetAttributes"" />    
  </appSettings>";

var settings = new XdtTransformationSettings().UseDefaultLogger();

XdtTransformConfig("./web.config", new XdtFragmentSource(fragment), settings);

if(settings.Logger.HasWarning)
{
...
```
This is generally how I've approached this change.  Given the patterns in play and the commonality with the existing code, we could refactor much of the current `XdtTransformation` class toward this without any risk of a breaking change, but that's more about polishing than core functionality 👍 

I have a few open items around tests that are still to be done, as well as a cleaning of commits/commit messages; this is by no means complete.  I wanted to get something that accurately represents the patterns & implementations up for others to review and provide feedback on before pushing forward with the tests, etc.

(Speaking of tests, I've added a ref to Moq to facilitate some of the stubs)

Please let me know if the patterns make sense and provide a reasonable, extensible solution.  If there are concerns or additional ideas on the approach, let me know.

Thanks.

cc: @augustoproiete 



