### PR TITLE
GH-62: Fix usages of equality assertions for FluentAssertions

### DIFF
--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogEntryTests.cs
@@ -14,7 +14,7 @@ namespace Cake.XdtTransform.Tests {
 
             CultureUtil.UseGBCulture(() => { stringRepresentation = item.ToString(); });
 
-            stringRepresentation.Should().Equals("[02/01/2000 03:04:05] ");
+            stringRepresentation.Should().Be("[02/01/2000 03:04:05] ");
         }
 
         [Fact]

--- a/src/Cake.XdtTransform.Tests/XdtTransformationLogTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationLogTests.cs
@@ -15,55 +15,55 @@ namespace Cake.XdtTransform.Tests {
                 log.HasError.Should().BeFalse();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeFalse();
-                log.Log.Count().Should().Equals(0);
+                log.Log.Should().HaveCount(0);
 
                 log.LogMessage("Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeFalse();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeFalse();
-                log.Log.Count().Should().Equals(1);
+                log.Log.Should().HaveCount(1);
                 log.Log.ElementAt(0).ToString().Should().Contain("[MessageType:Message] Message 1 2");
 
                 log.LogMessage(MessageType.Verbose, "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeFalse();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeFalse();
-                log.Log.Count().Should().Equals(2);
+                log.Log.Should().HaveCount(2);
                 log.Log.ElementAt(1).ToString().Should().Contain("[MessageType:Message] [MessageVerbosityType:Verbose] Message 1 2");
 
                 log.LogWarning("File", "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeFalse();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(3);
+                log.Log.Should().HaveCount(3);
                 log.Log.ElementAt(2).ToString().Should().Contain("[MessageType:Warning] [File:File] Message 1 2");
 
                 log.LogWarning("File", 30, 40, "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeFalse();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(4);
+                log.Log.Should().HaveCount(4);
                 log.Log.ElementAt(3).ToString().Should().Contain("[MessageType:Warning] [File:File] [LineNumber:30] [LinePosition:40] Message 1 2");
 
                 log.LogError("Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(5);
+                log.Log.Should().HaveCount(5);
                 log.Log.ElementAt(4).ToString().Should().Contain("[MessageType:Error] Message 1 2");
 
                 log.LogError("File", "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(6);
+                log.Log.Should().HaveCount(6);
                 log.Log.ElementAt(5).ToString().Should().Contain("[MessageType:Error] [File:File] Message 1 2");
 
                 log.LogError("File", 30, 40, "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeFalse();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(7);
+                log.Log.Should().HaveCount(7);
                 log.Log.ElementAt(6).ToString().Should().Contain("[MessageType:Error] [File:File] [LineNumber:30] [LinePosition:40] Message 1 2");
 
                 Exception exception = null;
@@ -78,49 +78,49 @@ namespace Cake.XdtTransform.Tests {
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(8);
+                log.Log.Should().HaveCount(8);
                 log.Log.ElementAt(7).ToString().Should().Contain("[MessageType:Exception] Exception: System.Exception: Exception was thrown");
 
                 log.LogErrorFromException(exception, "File");
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(9);
+                log.Log.Should().HaveCount(9);
                 log.Log.ElementAt(8).ToString().Should().Contain("[MessageType:Exception] [File:File] Exception: System.Exception: Exception was thrown");
 
                 log.LogErrorFromException(exception, "File", 30, 40);
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(10);
+                log.Log.Should().HaveCount(10);
                 log.Log.ElementAt(9).ToString().Should().Contain("[MessageType:Exception] [File:File] [LineNumber:30] [LinePosition:40] Exception: System.Exception: Exception was thrown");
 
                 log.StartSection("Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(11);
+                log.Log.Should().HaveCount(11);
                 log.Log.ElementAt(10).ToString().Should().Contain("[MessageType:Section] Message 1 2");
 
                 log.StartSection(MessageType.Verbose, "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(12);
+                log.Log.Should().HaveCount(12);
                 log.Log.ElementAt(11).ToString().Should().Contain("[MessageType:Section] [MessageVerbosityType:Verbose] Message 1 2");
 
                 log.EndSection("Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(13);
+                log.Log.Should().HaveCount(13);
                 log.Log.ElementAt(12).ToString().Should().Contain("[MessageType:Section] Message 1 2");
 
                 log.EndSection(MessageType.Verbose, "Message {0} {1}", new object[] {"1", 2});
                 log.HasError.Should().BeTrue();
                 log.HasException.Should().BeTrue();
                 log.HasWarning.Should().BeTrue();
-                log.Log.Count().Should().Equals(14);
+                log.Log.Should().HaveCount(14);
                 log.Log.ElementAt(13).ToString().Should().Contain("[MessageType:Section] [MessageVerbosityType:Verbose] Message 1 2");
             });
         }

--- a/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
+++ b/src/Cake.XdtTransform.Tests/XdtTransformationTests.cs
@@ -15,7 +15,7 @@ namespace Cake.XdtTransform.Tests {
             var result = Record.Exception(() => fixture.TransformConfig());
 
             // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Equals("sourceFile");
+            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("sourceFile");
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace Cake.XdtTransform.Tests {
             var result = Record.Exception(() => fixture.TransformConfig());
 
             // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Equals("transformFile");
+            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("transformFile");
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Cake.XdtTransform.Tests {
             var result = Record.Exception(() => fixture.TransformConfig());
 
             // Then
-            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Equals("targetFile");
+            result.Should().BeOfType<ArgumentNullException>().Subject.ParamName.Should().Be("targetFile");
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Cake.XdtTransform.Tests {
             log.HasError.Should().BeFalse();
             log.HasException.Should().BeFalse();
             log.HasWarning.Should().BeTrue();
-            log.Log.Count.Should().Equals(15);
+            log.Log.Count.Should().Be(15);
         }
 
         [Fact]


### PR DESCRIPTION
This removes all the current usages of 'Equals' which are the calls to
the base System.Object "Equals" method and perform no assertion
and shift them to the appropriate FluentAssertions methods on
their respective *Assertions types to continue/complete the method chain.

